### PR TITLE
Fixes #10, broken build after checkout because of missing certificate configuration

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,7 +22,7 @@ timestamps {
 
             try {
 
-                gradle '-x signArchives clean build'
+                gradle '-Psign -x signArchives clean build'
 
             } finally {
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,21 +1,21 @@
 /* scenarioo-api
  * Copyright (C) 2014, scenarioo.org Development Team
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * As a special exception, the copyright holders of this library give you 
- * permission to link this library with independent modules, according 
+ * As a special exception, the copyright holders of this library give you
+ * permission to link this library with independent modules, according
  * to the GNU General Public License with "Classpath" exception as provided
  * in the LICENSE file that accompanied this code.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -29,11 +29,11 @@ apply plugin: 'java'
 apply plugin: 'maven'
 apply plugin: 'signing'
 
-sourceCompatibility=1.6
-targetCompatibility=1.6
+sourceCompatibility = 1.6
+targetCompatibility = 1.6
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
@@ -59,8 +59,10 @@ artifacts {
     archives javadocJar, sourcesJar
 }
 
-signing {
-    sign configurations.archives
+if (project.hasProperty('sign')) {
+    signing {
+        sign configurations.archives
+    }
 }
 
 tasks.withType(Javadoc) {
@@ -70,7 +72,11 @@ tasks.withType(Javadoc) {
 uploadArchives {
     repositories {
         mavenDeployer {
-            beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
+            if (project.hasProperty('sign')) {
+                beforeDeployment {
+                    MavenDeployment deployment -> signing.signPom(deployment)
+                }
+            }
 
             repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
                 authentication(userName: ossrhUsername, password: ossrhPassword)

--- a/docs/upload-to-maven-central.md
+++ b/docs/upload-to-maven-central.md
@@ -1,19 +1,21 @@
 # Upload to maven central
+
 ## Snapshot
-1. You will need to specify the following properties in your gradle.properties located in your gradle home directory:
 
-```
-signing.keyId=BDCAAE60
-signing.password=#private key goes here#
-signing.secretKeyRingFile=#secret key file goes here#
-ossrhUsername=scenarioo
-ossrhPassword=#sonatype password goes here#
-```
+1.  You will need to specify the following properties in your `gradle.properties` located in your gradle home directory:
 
-2. Change the version appropriately in the build.gradle
-3. `gradlew clean uploadArchives`
+    ```
+    signing.keyId=BDCAAE60
+    signing.password=#private key goes here#
+    signing.secretKeyRingFile=#secret key file goes here#
+    ossrhUsername=scenarioo
+    ossrhPassword=#sonatype password goes here#
+    ```
+
+2. Change the version appropriately in the `build.gradle`
+3. `gradlew clean uploadArchives -Psign`
 
 ## Releases
-Same steps as for snapshot releases and
-4. Promote build to maven central:
+
+Same steps as for snapshot releases and then promote build to maven central:
 http://central.sonatype.org/pages/releasing-the-deployment.html


### PR DESCRIPTION
Taken from: https://github.com/stianh/gradle-jaxb-plugin/commit/ff912752fe7d83013497305fe038652b530b6866

This enables other developers to locally do a gradle install of their own versions without being stopped because the build want to sign the artifacts first.

To enable signing now, one must set the project property sign, like this:

gradle -Psign