### PR TITLE
Adjust docu to reflect current situation with artifact signing and artifact publishing not automated on CI

### DIFF
--- a/docs/release-new-api.md
+++ b/docs/release-new-api.md
@@ -9,14 +9,14 @@ The `scenarioo-java` repository has two branches: `develop` for developing the n
 Precondition: Before considering a release, make sure that the new version is well tested. If you are not 100% sure about the quality of the code, make a release candidate first and test it well in a realistic environment.
 
 1. Finalize the code in the `develop` branch of `scenarioo-java` by setting the correct version number in the `build.gradle` file. This version number must not exist yet in mavem central. Remove `SNAPSHOT` from the version number and add `-RCx` for release candidates where `x` is the RC number for further release candidate testing.
-2. Everytime you push to develop our jenkins CI will automatically upload a new version of the release candidate to our sonatype maven repo (see also [Publish release to maven central](upload-to-maven-central.md)).
+2. You have to manually [Publish the signed snapshot to maven central](upload-to-maven-central.md)) this is currently not automated.
 3. Make sure the changelog.md is updated for the new version
 
 ## Final Release to master branch
  
 1. Precondition: see Prepare Release above.
 2. Set the final version number in develop or release branch (without `-SNAPSHOT` or `-RC`) in `build.gradle` and merge it to the develop branch (or the release branch).
-3. The Jenkins CI will automatically publish the final release from that branch and under that version number for you to our sonatype maven repository (see also [Publish release to maven central](upload-to-maven-central.md) in case you want to do this manually).
+3. You have to manually [Publish the signed release to maven central](upload-to-maven-central.md)) this is currently not automated.
 4. Promote the final release to maven central: http://central.sonatype.org/pages/releasing-the-deployment.html
 5. Add a tag with the release version number to the commit where you set that version number and push the tag.
 6. **Write Release Notes** for the new release on GitHub ([here](https://github.com/scenarioo/scenarioo-java/releases))


### PR DESCRIPTION
Update release docu - because publishing of snapshots and releases currently not automated

@danielsuter this got forgotten - can you please check whether rest of docu is okay and to somehow document where developers can get the keys from in case they need to do snapshots??